### PR TITLE
RFC: Add mutable variant of query iterator

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -141,7 +141,7 @@ fn get_component_mutably(bencher: &mut Bencher) {
     spawn_few(&mut world);
 
     let entities = Query::<&Entity>::new()
-        .iter(&world)
+        .iter_mut(&mut world)
         .copied()
         .collect::<Vec<_>>();
 
@@ -180,6 +180,25 @@ fn query_single_archetype(bencher: &mut Bencher) {
 }
 
 #[bench]
+fn query_single_archetype_mutably(bencher: &mut Bencher) {
+    let mut world = World::new();
+    let mut query = Query::<(&mut Pos, &Vel)>::new();
+
+    spawn_few(&mut world);
+
+    let _ = query.iter_mut(&mut world);
+
+    bencher.iter(|| {
+        let world = black_box(&mut world);
+        let query = black_box(&mut query);
+
+        for (pos, vel) in query.iter_mut(world) {
+            pos.0 += vel.0;
+        }
+    });
+}
+
+#[bench]
 fn query_many_archetypes(bencher: &mut Bencher) {
     let mut world = World::new();
     let mut query = Query::<(&mut Pos, &Vel)>::new();
@@ -201,6 +220,25 @@ fn query_many_archetypes(bencher: &mut Bencher) {
 }
 
 #[bench]
+fn query_many_archetypes_mutably(bencher: &mut Bencher) {
+    let mut world = World::new();
+    let mut query = Query::<(&mut Pos, &Vel)>::new();
+
+    spawn_few_in_many_archetypes(&mut world);
+
+    let _ = query.iter_mut(&mut world);
+
+    bencher.iter(|| {
+        let world = black_box(&mut world);
+        let query = black_box(&mut query);
+
+        for (pos, vel) in query.iter_mut(world) {
+            pos.0 += vel.0;
+        }
+    });
+}
+
+#[bench]
 fn query_very_many_small_archetypes(bencher: &mut Bencher) {
     let mut world = World::new();
     let mut query = Query::<(&mut Pos, &Vel)>::new();
@@ -218,6 +256,25 @@ fn query_very_many_small_archetypes(bencher: &mut Bencher) {
                 pos.0 += vel.0;
             }
         });
+    });
+}
+
+#[bench]
+fn query_very_many_small_archetypes_mutably(bencher: &mut Bencher) {
+    let mut world = World::new();
+    let mut query = Query::<(&mut Pos, &Vel)>::new();
+
+    spawn_few_in_very_many_small_archetypes(&mut world);
+
+    let _ = query.iter_mut(&mut world);
+
+    bencher.iter(|| {
+        let world = black_box(&mut world);
+        let query = black_box(&mut query);
+
+        for (pos, vel) in query.iter_mut(world) {
+            pos.0 += vel.0;
+        }
     });
 }
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -135,6 +135,30 @@ fn get_component(bencher: &mut Bencher) {
 }
 
 #[bench]
+fn get_component_mutably(bencher: &mut Bencher) {
+    let mut world = World::new();
+
+    spawn_few(&mut world);
+
+    let entities = Query::<&Entity>::new()
+        .iter(&world)
+        .copied()
+        .collect::<Vec<_>>();
+
+    let mut entities = entities.iter().cycle();
+
+    bencher.iter(|| {
+        let world = black_box(&mut world);
+        let entities = black_box(&mut entities);
+
+        let ent = *entities.next().unwrap();
+
+        let _pos = world.mut_get_mut::<Pos>(ent).unwrap();
+        let _vel = world.mut_get_mut::<Vel>(ent);
+    });
+}
+
+#[bench]
 fn query_single_archetype(bencher: &mut Bencher) {
     let mut world = World::new();
     let mut query = Query::<(&mut Pos, &Vel)>::new();
@@ -207,5 +231,18 @@ fn get_resource(bencher: &mut Bencher) {
     bencher.iter(|| {
         let _i32 = resources.get_mut::<i32>();
         let _f64 = resources.get::<f64>();
+    });
+}
+
+#[bench]
+fn get_resource_mutably(bencher: &mut Bencher) {
+    let mut resources = Resources::new();
+
+    resources.insert(23);
+    resources.insert(42.0);
+
+    bencher.iter(|| {
+        let _i32 = resources.mut_get_mut::<i32>();
+        let _f64 = resources.mut_get_mut::<f64>();
     });
 }

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -267,6 +267,17 @@ impl Archetype {
 
         (*self.ptr.get()).as_ptr().add(ty.offset).cast::<C>()
     }
+
+    pub unsafe fn pointer<C>(&self, ty: usize) -> *mut C
+    where
+        C: 'static,
+    {
+        debug_assert!(ty < self.types.len());
+        let ty = self.types.get_unchecked(ty);
+        debug_assert_eq!(ty.id, TypeId::of::<C>());
+
+        (*self.ptr.get()).as_ptr().add(ty.offset).cast::<C>()
+    }
 }
 
 impl Archetype {
@@ -298,6 +309,20 @@ impl Archetype {
         let val = &mut *ptr.add(idx as usize);
 
         Some(CompMut { _ref, val })
+    }
+
+    pub unsafe fn mut_get_mut<C>(&mut self, idx: u32) -> Option<&mut C>
+    where
+        C: 'static,
+    {
+        debug_assert!(idx < self.len);
+
+        let ty = self.find::<C>()?;
+        let ptr = self.pointer::<C>(ty);
+
+        let val = &mut *ptr.add(idx as usize);
+
+        Some(val)
     }
 }
 

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -267,17 +267,6 @@ impl Archetype {
 
         (*self.ptr.get()).as_ptr().add(ty.offset).cast::<C>()
     }
-
-    pub unsafe fn pointer<C>(&self, ty: usize) -> *mut C
-    where
-        C: 'static,
-    {
-        debug_assert!(ty < self.types.len());
-        let ty = self.types.get_unchecked(ty);
-        debug_assert_eq!(ty.id, TypeId::of::<C>());
-
-        (*self.ptr.get()).as_ptr().add(ty.offset).cast::<C>()
-    }
 }
 
 impl Archetype {

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -47,6 +47,15 @@ impl Resources {
             &mut *(ref_.deref_mut() as *mut dyn Any as *mut R)
         }))
     }
+
+    pub fn mut_get_mut<R>(&mut self) -> &mut R
+    where
+        R: 'static,
+    {
+        let res = self.0.get_mut(&TypeId::of::<R>()).unwrap().get_mut();
+
+        unsafe { &mut *(res.deref_mut() as *mut dyn Any as *mut R) }
+    }
 }
 
 pub struct Res<'a, R>(Ref<'a, R>);
@@ -114,6 +123,21 @@ mod tests {
 
         {
             let mut res = resources.get_mut::<u64>();
+            *res = 23;
+        }
+
+        let res = resources.get::<u64>();
+        assert_eq!(*res, 23);
+    }
+
+    #[test]
+    fn mut_get_mut_then_get() {
+        let mut resources = Resources::new();
+
+        resources.insert(42_u64);
+
+        {
+            let res = resources.mut_get_mut::<u64>();
             *res = 23;
         }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -234,6 +234,20 @@ impl World {
 
         unsafe { self.archetypes[meta.ty as usize].get_mut::<C>(meta.idx) }
     }
+
+    pub fn mut_get_mut<C>(&mut self, ent: Entity) -> Option<&mut C>
+    where
+        C: 'static,
+    {
+        if TypeId::of::<C>() == TypeId::of::<Entity>() {
+            panic!("Entity cannot be accessed mutably");
+        }
+
+        let meta = &self.entities[ent.id as usize];
+        assert_eq!(ent.gen, meta.gen);
+
+        unsafe { self.archetypes[meta.ty as usize].mut_get_mut::<C>(meta.idx) }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -510,6 +524,22 @@ mod tests {
 
         {
             let mut comp = world.get_mut::<i32>(ent).unwrap();
+            *comp = 42;
+        }
+
+        let comp = world.get::<i32>(ent).unwrap();
+        assert_eq!(*comp, 42);
+    }
+
+    #[test]
+    fn mut_get_mut_then_get() {
+        let mut world = World::new();
+
+        let ent = world.alloc();
+        world.insert(ent, (23,));
+
+        {
+            let comp = world.mut_get_mut::<i32>(ent).unwrap();
             *comp = 42;
         }
 


### PR DESCRIPTION
While working on https://github.com/Ralith/hecs/pull/159 I noticed that the lead of the mutable query variants seems larger with prepared queries, so I reconsidered whether we should include them in our simplified API with this PR being the result.

The performance seems favourable,  especially if a lot of small archetypes are involved (which however should not be the case for our simulation models), c.f.
```
test query_single_archetype                   ... bench:         536 ns/iter (+/- 3)
test query_single_archetype_mutably           ... bench:         399 ns/iter (+/- 4)

test query_many_archetypes                    ... bench:         752 ns/iter (+/- 8)
test query_many_archetypes_mutably            ... bench:         501 ns/iter (+/- 17)

test query_very_many_small_archetypes         ... bench:         721 ns/iter (+/- 19)
test query_very_many_small_archetypes_mutably ... bench:         182 ns/iter (+/- 3)
```

From a perspective of code complexity, we need only one additional public method on the existing query type to support this. It would also be possible to reuse the existing query iterator but then the performance wins are almost negligible.

I am also rather unsure about the funnily named `mut_get_mut` methods to mutably access single components or resources as the performance gains are limited, c.f.
```
test get_component                            ... bench:          18 ns/iter (+/- 1)
test get_component_mutably                    ... bench:          16 ns/iter (+/- 0)

test get_resource                             ... bench:          10 ns/iter (+/- 0)
test get_resource_mutably                     ... bench:           7 ns/iter (+/- 0)
```
and the usage would be severely limited as only one component could accessed this way at any time in contrast to queries where a single mutable borrow on the world can give access to multiple components. 