### PR TITLE
Fix unsoundness in query iteration API

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -95,10 +95,7 @@ fn insert_remove(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let entities = Query::<&Entity>::new()
-        .iter(&world)
-        .copied()
-        .collect::<Vec<_>>();
+    let entities = Query::<&Entity>::new().iter(&world, |iter| iter.copied().collect::<Vec<_>>());
 
     let mut entities = entities.iter().cycle();
 
@@ -122,10 +119,7 @@ fn get_component(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let entities = Query::<&Entity>::new()
-        .iter(&world)
-        .copied()
-        .collect::<Vec<_>>();
+    let entities = Query::<&Entity>::new().iter(&world, |iter| iter.copied().collect::<Vec<_>>());
 
     let mut entities = entities.iter().cycle();
 
@@ -147,15 +141,17 @@ fn query_single_archetype(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let _ = query.iter(&world);
+    query.iter(&world, |_iter| {});
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        for (pos, vel) in query.iter(world) {
-            pos.0 += vel.0;
-        }
+        query.iter(world, |iter| {
+            for (pos, vel) in iter {
+                pos.0 += vel.0;
+            }
+        });
     });
 }
 
@@ -166,15 +162,17 @@ fn query_many_archetypes(bencher: &mut Bencher) {
 
     spawn_few_in_many_archetypes(&mut world);
 
-    let _ = query.iter(&world);
+    query.iter(&world, |_iter| {});
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        for (pos, vel) in query.iter(world) {
-            pos.0 += vel.0;
-        }
+        query.iter(world, |iter| {
+            for (pos, vel) in iter {
+                pos.0 += vel.0;
+            }
+        });
     });
 }
 
@@ -185,15 +183,17 @@ fn query_very_many_small_archetypes(bencher: &mut Bencher) {
 
     spawn_few_in_very_many_small_archetypes(&mut world);
 
-    let _ = query.iter(&world);
+    query.iter(&world, |_iter| {});
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        for (pos, vel) in query.iter(world) {
-            pos.0 += vel.0;
-        }
+        query.iter(world, |iter| {
+            for (pos, vel) in iter {
+                pos.0 += vel.0;
+            }
+        });
     });
 }
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -95,7 +95,11 @@ fn insert_remove(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let entities = Query::<&Entity>::new().iter(&world, |iter| iter.copied().collect::<Vec<_>>());
+    let entities = Query::<&Entity>::new()
+        .borrow(&world)
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
 
     let mut entities = entities.iter().cycle();
 
@@ -119,7 +123,11 @@ fn get_component(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let entities = Query::<&Entity>::new().iter(&world, |iter| iter.copied().collect::<Vec<_>>());
+    let entities = Query::<&Entity>::new()
+        .borrow(&world)
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
 
     let mut entities = entities.iter().cycle();
 
@@ -141,17 +149,15 @@ fn query_single_archetype(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    query.iter(&world, |_iter| {});
+    let _ = query.borrow(&world).iter();
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        query.iter(world, |iter| {
-            for (pos, vel) in iter {
-                pos.0 += vel.0;
-            }
-        });
+        for (pos, vel) in query.borrow(world).iter() {
+            pos.0 += vel.0;
+        }
     });
 }
 
@@ -162,17 +168,15 @@ fn query_many_archetypes(bencher: &mut Bencher) {
 
     spawn_few_in_many_archetypes(&mut world);
 
-    query.iter(&world, |_iter| {});
+    let _ = query.borrow(&world).iter();
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        query.iter(world, |iter| {
-            for (pos, vel) in iter {
-                pos.0 += vel.0;
-            }
-        });
+        for (pos, vel) in query.borrow(world).iter() {
+            pos.0 += vel.0;
+        }
     });
 }
 
@@ -183,17 +187,15 @@ fn query_very_many_small_archetypes(bencher: &mut Bencher) {
 
     spawn_few_in_very_many_small_archetypes(&mut world);
 
-    query.iter(&world, |_iter| {});
+    let _ = query.borrow(&world).iter();
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        query.iter(world, |iter| {
-            for (pos, vel) in iter {
-                pos.0 += vel.0;
-            }
-        });
+        for (pos, vel) in query.borrow(world).iter() {
+            pos.0 += vel.0;
+        }
     });
 }
 

--- a/src/archetype.rs
+++ b/src/archetype.rs
@@ -242,7 +242,11 @@ impl Archetype {
         let ty = self.types.get_unchecked(ty);
         debug_assert_eq!(ty.id, TypeId::of::<C>());
 
-        let ref_ = ty.borrow.borrow();
+        let ref_ = ty
+            .borrow
+            .try_borrow()
+            .unwrap_or_else(|_err| panic!("Component {} already borrowed", type_name::<C>()));
+
         let ptr = (*self.ptr.get()).as_ptr().add(ty.offset).cast::<C>();
 
         (ref_, ptr)
@@ -256,7 +260,11 @@ impl Archetype {
         let ty = self.types.get_unchecked(ty);
         debug_assert_eq!(ty.id, TypeId::of::<C>());
 
-        let ref_ = ty.borrow.borrow_mut();
+        let ref_ = ty
+            .borrow
+            .try_borrow_mut()
+            .unwrap_or_else(|_err| panic!("Component {} already borrowed", type_name::<C>()));
+
         let ptr = (*self.ptr.get()).as_ptr().add(ty.offset).cast::<C>();
 
         (ref_, ptr)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod world;
 
 pub use crate::{
     archetype::{Comp, CompMut},
-    query::{Query, QueryIter, QuerySpec, With, Without},
+    query::{Query, QueryIter, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
     world::{Entity, World},
 };

--- a/src/query.rs
+++ b/src/query.rs
@@ -44,7 +44,7 @@ where
 
     pub fn iter<'q, F, T>(&'q mut self, world: &'q World, f: F) -> T
     where
-        F: FnOnce(QueryIter<'q, S>) -> T,
+        F: for<'i> FnOnce(QueryIter<'i, S>) -> T,
     {
         let tag_gen = world.tag_gen();
         let archetypes = world.archetypes();


### PR DESCRIPTION
As any iterator can be dropped before the references it yielded, it is unsound to release our borrows on the components in the `Drop` implementation, they must be held for as long as the references can live, specifically for the duration of the lifetime `'q`. But currently, code like this
```rust
let iter = query.iter(word);
let vals = iter.collect::<Vec<_>>();

for val in vals {
  // Do something using `val` even though `iter` was dropped and hence the borrows release.
}
```
is accepted.

There are two options two resolve this:
* Use a closure like implemented in this PR to put a drop guard on the stack which will release the borrows when the closure returns or unwinds. Of course, the closure looks weird/noisy as an API, e.g.
```rust
query.iter(world, |iter| {
    for (pos, vel) in iter {
        pos.0 += vel.0;
    }
});
```
* Use an intermediate object that encapsulates the borrows and from which an iterator can be derived. Calling API looks less weird, but the intermediate object is also harder to explain to a reader IMHO. And it has the additional paper cut that the iterator can only be derived once, e.g.
```rust
let query = query.borrow(world);

for (pos, val) in query.iter() {
    pos.0 += vel.0;
}

// This will panic because `query` was already "used up" by the previous call to `iter`
let cnt = query.iter().count();
```

Performance is unaffected compared to the main branch.