### PR TITLE
Alternative mode of separation

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -95,7 +95,11 @@ fn insert_remove(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let entities = Query::<&Entity>::new().iter(&world, |iter| iter.copied().collect::<Vec<_>>());
+    let entities = Query::<&Entity>::new()
+        .borrow(&world)
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
 
     let mut entities = entities.iter().cycle();
 
@@ -119,7 +123,11 @@ fn get_component(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    let entities = Query::<&Entity>::new().iter(&world, |iter| iter.copied().collect::<Vec<_>>());
+    let entities = Query::<&Entity>::new()
+        .borrow(&world)
+        .iter()
+        .copied()
+        .collect::<Vec<_>>();
 
     let mut entities = entities.iter().cycle();
 
@@ -141,17 +149,15 @@ fn query_single_archetype(bencher: &mut Bencher) {
 
     spawn_few(&mut world);
 
-    query.iter(&world, |_iter| {});
+    let _ = query.borrow(&world).iter();
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        query.iter(world, |iter| {
-            for (pos, vel) in iter {
-                pos.0 += vel.0;
-            }
-        });
+        for (pos, vel) in query.borrow(world).iter() {
+            pos.0 += vel.0;
+        }
     });
 }
 
@@ -162,17 +168,15 @@ fn query_many_archetypes(bencher: &mut Bencher) {
 
     spawn_few_in_many_archetypes(&mut world);
 
-    query.iter(&world, |_iter| {});
+    let _ = query.borrow(&world).iter();
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        query.iter(world, |iter| {
-            for (pos, vel) in iter {
-                pos.0 += vel.0;
-            }
-        });
+        for (pos, vel) in query.borrow(world).iter() {
+            pos.0 += vel.0;
+        }
     });
 }
 
@@ -183,17 +187,15 @@ fn query_very_many_small_archetypes(bencher: &mut Bencher) {
 
     spawn_few_in_very_many_small_archetypes(&mut world);
 
-    query.iter(&world, |_iter| {});
+    let _ = query.borrow(&world).iter();
 
     bencher.iter(|| {
         let world = black_box(&world);
         let query = black_box(&mut query);
 
-        query.iter(world, |iter| {
-            for (pos, vel) in iter {
-                pos.0 += vel.0;
-            }
-        });
+        for (pos, vel) in query.borrow(world).iter() {
+            pos.0 += vel.0;
+        }
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ mod world;
 
 pub use crate::{
     archetype::{Comp, CompMut},
-    query::{Query, QueryIter, QuerySpec, With, Without},
+    query::{Query, QueryIter, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
     world::{Entity, World},
 };


### PR DESCRIPTION
Introduces an intermediate type to hold the borrows longer than the iterator exists.