### PR TITLE
RFC: Add query map to enable access to query results by entity ID

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod world;
 
 pub use crate::{
     archetype::{Comp, CompMut},
-    query::{Query, QueryIter, QueryRef, QuerySpec, With, Without},
+    query::{Query, QueryIter, QueryMap, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
     world::{Entity, World},
 };

--- a/src/query.rs
+++ b/src/query.rs
@@ -251,6 +251,27 @@ where
     }
 
     /// Create a map of the entities matching the query.
+    ///
+    /// This is an alternative to [World::get()]/[World::get_mut()] for repeated calls, to amortize the set-up costs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use rs_ecs::*;
+    /// let mut world = World::new();
+    ///
+    /// let entity = world.alloc();
+    /// world.insert(entity, (42_i32, 1.0_f32));
+    ///
+    /// let mut query = Query::<(&i32, &f32)>::new();
+    /// let mut query = query.borrow(&world);
+    /// let mut query = query.map();
+    ///
+    /// let (i, f) = query.get(entity).unwrap();
+    ///
+    /// assert_eq!(*i, 42);
+    /// assert_eq!(*f, 1.0);
+    /// ```
     pub fn map<'q>(&'q mut self) -> QueryMap<'q, S> {
         let types: &'q [(usize, <S::Fetch as Fetch<'q>>::Ty)] = unsafe { transmute(self.types) };
         let ptrs: &'q mut Vec<(u32, <S::Fetch as Fetch<'q>>::Ptr)> =
@@ -342,6 +363,7 @@ where
 }
 
 /// Provides random access to the entities which match a certain [Query].
+/// For details, see [QueryRef::map()].
 pub struct QueryMap<'q, S>
 where
     S: QuerySpec,

--- a/src/world.rs
+++ b/src/world.rs
@@ -10,9 +10,9 @@ use crate::archetype::{Archetype, Comp, CompMut, TypeMetadataSet};
 /// The ECS world storing [Entities](Entity) and components.
 pub struct World {
     tag: u32,
-    entities: Vec<EntityMetadata>,
+    pub(crate) entities: Vec<EntityMetadata>,
     free_list: Vec<u32>,
-    archetypes: Vec<Archetype>,
+    pub(crate) archetypes: Vec<Archetype>,
     insert_map: HashMap<(u32, TypeId), u32, BuildHasherDefault<IndexTypeIdHasher>>,
     remove_map: HashMap<(u32, TypeId), u32, BuildHasherDefault<IndexTypeIdHasher>>,
 }
@@ -126,10 +126,6 @@ impl World {
     pub(crate) fn tag_gen(&self) -> (u32, u32) {
         debug_assert!(!self.archetypes.is_empty());
         (self.tag, self.archetypes.len() as u32)
-    }
-
-    pub(crate) fn archetypes(&self) -> &[Archetype] {
-        &self.archetypes
     }
 
     /// Insert components for a given [Entity].
@@ -338,15 +334,15 @@ impl World {
 /// An opaque entity identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Entity {
-    id: u32,
-    gen: NonZeroU32,
+    pub(crate) id: u32,
+    pub(crate) gen: NonZeroU32,
 }
 
 #[derive(Clone, Copy)]
-struct EntityMetadata {
-    gen: NonZeroU32,
-    ty: u32,
-    idx: u32,
+pub struct EntityMetadata {
+    pub gen: NonZeroU32,
+    pub ty: u32,
+    pub idx: u32,
 }
 
 impl Default for EntityMetadata {

--- a/src/world.rs
+++ b/src/world.rs
@@ -282,6 +282,8 @@ impl World {
 
     /// Get an immutable reference to the component of the given type for an [Entity].
     ///
+    /// Note that for repeated calls, [QueryRef::map()](struct.QueryRef.html#method.map) can be used to amortize the set-up costs.
+    ///
     /// # Example
     ///
     /// ```
@@ -304,6 +306,8 @@ impl World {
     }
 
     /// Get a mutable reference to the component of the given type for an [Entity].
+    ///
+    /// Note that for repeated calls, [QueryRef::map()](struct.QueryRef.html#method.map) can be used to amortize the set-up costs.
     ///
     /// # Example
     ///


### PR DESCRIPTION
This provides the `QueryMap` type which provides access to query results by entity ID.

This could reduce the overhead of `World::get{,_mut}` for the grid-entity-component indirection we use in `swifco-rs`. While this does add yet another component access API, it shows gains in micro benchmarks as well as when modifying `swifco-rs` to use this as done in MR !73. For micro benchmarks the time to fetch two components decreases from **12ns** to **3ns**. For `swifco-rs`, using it in the dispersal systems reduces the time to run 100 seeds (on 8 threads) from **1.1min** to **0.85min**.   