### PR TITLE
Add FetchShared trait and QueryMap::get to enable possibly aliasing shared random access to query results.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-ecs"
 description = "reasonably simple entity component system"
-version = "0.3.10"
+version = "0.4.0"
 edition = "2018"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]
 license = "MIT OR Apache-2.0"

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -272,7 +272,7 @@ fn query_map(bencher: &mut Bencher, spawn: fn(&mut World)) {
 
         let ent = *entities.next().unwrap();
 
-        let (_pos, _vel) = query.get(ent).unwrap();
+        let (_pos, _vel) = query.get_mut(ent).unwrap();
     });
 }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -306,7 +306,7 @@ where
     /// let mut query = query.borrow(&world);
     /// let mut query = query.map();
     ///
-    /// let (i, f) = query.get(entity).unwrap();
+    /// let (i, f) = query.get_mut(entity).unwrap();
     ///
     /// assert_eq!(*i, 42);
     /// assert_eq!(*f, 1.0);
@@ -415,8 +415,8 @@ impl<S> QueryMap<'_, S>
 where
     S: QuerySpec,
 {
-    /// Access the queried components of the given [Entity]
-    pub fn get<'m>(&'m mut self, ent: Entity) -> Option<<S::Fetch as Fetch<'m>>::Item> {
+    /// Exclusively access the queried components of the given [Entity]
+    pub fn get_mut<'m>(&'m mut self, ent: Entity) -> Option<<S::Fetch as Fetch<'m>>::Item> {
         let meta = self.entities[ent.id as usize];
         assert_eq!(ent.gen, meta.gen, "Entity is stale");
 
@@ -961,7 +961,7 @@ mod tests {
         let mut query = query.map();
 
         for ent in entities {
-            query.get(ent).unwrap();
+            query.get_mut(ent).unwrap();
         }
     }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -449,7 +449,7 @@ where
         assert_eq!(ent.gen, meta.gen, "Entity is stale");
 
         let ptr: &'m Option<<S::Fetch as Fetch<'m>>::Ptr> =
-            unsafe { transmute(&self.ptrs[meta.ty as usize]) };
+            unsafe { transmute(self.ptrs.get_unchecked(meta.ty as usize)) };
 
         ptr.map(|ptr| unsafe { S::Fetch::deref(ptr, meta.idx) })
     }
@@ -460,7 +460,7 @@ where
         assert_eq!(ent.gen, meta.gen, "Entity is stale");
 
         let ptr: &'m Option<<S::Fetch as Fetch<'m>>::Ptr> =
-            unsafe { transmute(&self.ptrs[meta.ty as usize]) };
+            unsafe { transmute(self.ptrs.get_unchecked(meta.ty as usize)) };
 
         ptr.map(|ptr| unsafe { S::Fetch::deref(ptr, meta.idx) })
     }


### PR DESCRIPTION
This will be required when cell and edge information will be stored using the ECS instead of separate `Grid` resources.