### PR TITLE
Add Matches query combinator to indicate which entities match a query without borrowing any components

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-ecs"
 description = "reasonably simple entity component system"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2018"
 rust-version = "1.51"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod world;
 
 pub use crate::{
     archetype::{Comp, CompMut},
-    query::{Query, QueryIter, QueryMap, QueryRef, QuerySpec, With, Without},
+    query::{Matches, Query, QueryIter, QueryMap, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
     world::{Entity, World},
 };

--- a/src/query.rs
+++ b/src/query.rs
@@ -193,41 +193,6 @@ where
 
         self.tag_gen = world.tag_gen();
     }
-
-    /// Narrow down a query to entities that have a certain component,
-    /// without borrowing that component.
-    ///
-    /// For use with prepared queries, see [With].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use rs_ecs::*;
-    /// let query = Query::<(&i32,)>::new().with::<bool>();
-    /// ```
-    pub fn with<C>(self) -> Query<With<S, C>>
-    where
-        C: 'static,
-    {
-        Query::new()
-    }
-
-    /// Narrow down a query to entities that do not have a certain component.
-    ///
-    /// For use with prepared queries, see [Without].
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use rs_ecs::*;
-    /// let query = Query::<(&i32,)>::new().without::<bool>();
-    /// ```
-    pub fn without<C>(self) -> Query<Without<S, C>>
-    where
-        C: 'static,
-    {
-        Query::new()
-    }
 }
 
 /// Borrow of the [World] for a [Query]. Required to obtain an iterator.
@@ -624,8 +589,6 @@ unsafe impl<F> FetchShared for TryFetch<F> where F: FetchShared {}
 /// A query specification to iterate over entities with a certain component,
 /// but without borrowing that component.
 ///
-/// See also [Query::with()]
-///
 /// # Examples
 ///
 /// A query for components of type `u32` and `bool`,
@@ -685,8 +648,6 @@ where
 unsafe impl<F, C> FetchShared for FetchWith<F, C> where F: FetchShared {}
 
 /// A query specification to iterate over entities without a certain component.
-///
-/// See also [Query::without()]
 ///
 /// # Examples
 ///
@@ -982,7 +943,7 @@ mod tests {
 
         spawn_three(&mut world);
 
-        let mut query = Query::<&i32>::new().with::<bool>();
+        let mut query = Query::<With<&i32, bool>>::new();
         let sum = query.borrow(&world).iter().sum::<i32>();
 
         assert_eq!(sum, 42);
@@ -994,7 +955,7 @@ mod tests {
 
         spawn_three(&mut world);
 
-        let mut query = Query::<&i32>::new().without::<bool>();
+        let mut query = Query::<Without<&i32, bool>>::new();
         let sum = query.borrow(&world).iter().sum::<i32>();
 
         assert_eq!(sum, 23 + 1);

--- a/src/query.rs
+++ b/src/query.rs
@@ -25,6 +25,7 @@ use crate::rayon::QueryParIter;
 /// * `Option<Q>` - optional component(s)
 /// * `With<Q, C>` to filter `Q` for presence of `C`
 /// * `Without<Q, C>` to filter `Q` for absence of `C`
+/// * `Matches<Q> to indicate which entities match `Q`
 ///
 /// Note that [Entities](Entity) are components themselves, so they can be optionally obtained in a query,
 /// like `Query<Entity, &C, &mut D>`.
@@ -706,6 +707,75 @@ where
 }
 
 unsafe impl<F, C> FetchShared for FetchWithout<F, C> where F: FetchShared {}
+
+/// A query specification to indicate which entities match the inner query,
+/// but without borrowing any components.
+///
+/// # Examples
+///
+/// ```
+/// # use rs_ecs::*;
+/// let mut world = World::new();
+///
+/// let entity1 = world.alloc();
+/// world.insert(entity1, (42_i32, 1.0_f32));
+///
+/// let entity2 = world.alloc();
+/// world.insert(entity2, (23_i32,));
+///
+/// let mut query = Query::<(&i32, Matches<&f32>)>::new();
+/// let mut query = query.borrow(&world);
+/// let mut query = query.map();
+///
+/// let (i1, f1) = query.get(entity1).unwrap();
+/// assert_eq!(*i1, 42);
+/// assert!(f1);
+///
+/// let (i2, f2) = query.get(entity2).unwrap();
+/// assert_eq!(*i2, 23);
+/// assert!(!f2);
+/// ```
+pub struct Matches<S>(PhantomData<S>);
+
+impl<S> QuerySpec for Matches<S>
+where
+    S: QuerySpec,
+{
+    type Fetch = FetchMatches<S::Fetch>;
+}
+
+pub struct FetchMatches<F>(PhantomData<F>);
+
+unsafe impl<'q, F> Fetch<'q> for FetchMatches<F>
+where
+    F: Fetch<'q>,
+{
+    type Ty = bool;
+    type Ref = ();
+    type Ptr = bool;
+
+    type Item = bool;
+
+    fn find(archetype: &Archetype) -> Option<Self::Ty> {
+        Some(F::find(archetype).is_some())
+    }
+
+    unsafe fn borrow(_archetype: &'q Archetype, _ty: Self::Ty) -> Self::Ref {}
+
+    unsafe fn base_pointer(_archetype: &'q Archetype, ty: Self::Ty) -> Self::Ptr {
+        ty
+    }
+
+    fn dangling() -> Self::Ptr {
+        false
+    }
+
+    unsafe fn deref(ptr: Self::Ptr, _idx: u32) -> Self::Item {
+        ptr
+    }
+}
+
+unsafe impl<F> FetchShared for FetchMatches<F> {}
 
 macro_rules! impl_fetch_for_tuples {
     () => {};


### PR DESCRIPTION
This is basically a port of the `Satisfies` query combinator introduced in [hecs 0.7.0](https://github.com/Ralith/hecs/blob/master/CHANGELOG.md#070). This should be useful when e.g. query for the optional presence of marker components like `AsfInfected` in observers where we are not interested in the component value itself but only test `infected.is_some()`. 