### PR TITLE
Use global borrow flags to avoid per-archetype borrow checking overhead.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-ecs"
 description = "reasonably simple entity component system"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 rust-version = "1.51"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]

--- a/src/borrow_flags.rs
+++ b/src/borrow_flags.rs
@@ -1,0 +1,116 @@
+use std::any::{type_name, TypeId};
+use std::cell::UnsafeCell;
+
+use crate::archetype::TypeMetadataSet;
+
+#[derive(Default)]
+pub struct BorrowFlags(Vec<(TypeId, UnsafeCell<isize>)>);
+
+impl BorrowFlags {
+    pub fn insert(&mut self, types: &TypeMetadataSet) {
+        for id in types.ids() {
+            if let Err(idx) = self.0.binary_search_by_key(&id, |(id, _)| *id) {
+                assert!(self.0.len() < u16::MAX as usize);
+
+                self.0.insert(idx, (id, UnsafeCell::new(0)));
+            }
+        }
+    }
+
+    pub fn find<C>(&self) -> Option<u16>
+    where
+        C: 'static,
+    {
+        self.0
+            .binary_search_by_key(&TypeId::of::<C>(), |(id, _)| *id)
+            .map(|idx| idx as u16)
+            .ok()
+    }
+
+    unsafe fn flag<C>(&self, ty: u16) -> &UnsafeCell<isize>
+    where
+        C: 'static,
+    {
+        let ty = ty as usize;
+        debug_assert!(ty < self.0.len());
+        let (id, flag) = self.0.get_unchecked(ty);
+        debug_assert_eq!(id, &TypeId::of::<C>());
+
+        flag
+    }
+
+    pub unsafe fn borrow<C>(&self, ty: u16) -> Ref<'_>
+    where
+        C: 'static,
+    {
+        let flag = self.flag::<C>(ty);
+
+        Ref::new(flag).unwrap_or_else(|| panic!("Component {} already borrowed", type_name::<C>()))
+    }
+
+    pub unsafe fn borrow_mut<C>(&self, ty: u16) -> RefMut<'_>
+    where
+        C: 'static,
+    {
+        let flag = self.flag::<C>(ty);
+
+        RefMut::new(flag)
+            .unwrap_or_else(|| panic!("Component {} already borrowed", type_name::<C>()))
+    }
+}
+
+pub struct Ref<'a>(&'a UnsafeCell<isize>);
+
+impl<'a> Ref<'a> {
+    pub(crate) fn new(borrow: &'a UnsafeCell<isize>) -> Option<Self> {
+        let readers = unsafe { &mut *borrow.get() };
+
+        let new_readers = readers.wrapping_add(1);
+
+        if new_readers <= 0 {
+            cold();
+            return None;
+        }
+
+        *readers = new_readers;
+
+        Some(Self(borrow))
+    }
+}
+
+impl Drop for Ref<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            *self.0.get() -= 1;
+        }
+    }
+}
+
+pub struct RefMut<'a>(&'a UnsafeCell<isize>);
+
+impl<'a> RefMut<'a> {
+    pub(crate) fn new(borrow: &'a UnsafeCell<isize>) -> Option<Self> {
+        let writers = unsafe { &mut *borrow.get() };
+
+        if *writers != 0 {
+            cold();
+            return None;
+        }
+
+        *writers = -1;
+
+        Some(Self(borrow))
+    }
+}
+
+impl Drop for RefMut<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            *self.0.get() = 0;
+        }
+    }
+}
+
+#[cold]
+#[inline(always)]
+fn cold() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,15 +28,15 @@
 #![warn(missing_docs)]
 
 mod archetype;
+mod borrow_flags;
 mod query;
 mod resources;
 mod world;
 
 pub use crate::{
-    archetype::{Comp, CompMut},
     query::{Matches, Query, QueryIter, QueryMap, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
-    world::{Entity, World},
+    world::{Comp, CompMut, Entity, World},
 };
 
 #[cfg(feature = "rayon")]

--- a/src/rayon.rs
+++ b/src/rayon.rs
@@ -16,7 +16,7 @@ pub struct QueryParIter<'q, S>
 where
     S: QuerySpec,
 {
-    types: &'q [(u16, <S::Fetch as Fetch<'q>>::Ty)],
+    comps: &'q [(u16, <S::Fetch as Fetch<'q>>::Ty)],
     archetypes: &'q [Archetype],
     idx: u32,
     len: u32,
@@ -34,16 +34,16 @@ where
     S: QuerySpec,
 {
     pub(crate) fn new(
-        types: &'q [(u16, <S::Fetch as Fetch<'q>>::Ty)],
+        comps: &'q [(u16, <S::Fetch as Fetch<'q>>::Ty)],
         archetypes: &'q [Archetype],
     ) -> Self {
-        let len = types
+        let len = comps
             .iter()
             .map(|(idx, _ty)| archetypes[*idx as usize].len())
             .sum();
 
         Self {
-            types,
+            comps,
             archetypes,
             idx: 0,
             len,
@@ -119,7 +119,7 @@ where
         let mut len_back = 0;
         let mut ptr_back = S::Fetch::dangling();
 
-        for (pos, (archetype_idx, ty)) in self.types.iter().enumerate() {
+        for (pos, (archetype_idx, ty)) in self.comps.iter().enumerate() {
             let archetype = &self.archetypes[*archetype_idx as usize];
 
             if archetype.len() == 0 {
@@ -158,10 +158,10 @@ where
             }
         }
 
-        let types = &self.types[first..last];
+        let comps = &self.comps[first..last];
 
         QueryParIterIntoIter {
-            types,
+            comps,
             archetypes: self.archetypes,
             idx,
             len,
@@ -178,7 +178,7 @@ where
     {
         let mut sum = 0;
 
-        for (archetype_idx, ty) in self.types {
+        for (archetype_idx, ty) in self.comps {
             if self.len <= sum {
                 break;
             }
@@ -225,14 +225,14 @@ where
         let mid = self.idx + mid as u32;
 
         let lhs = Self {
-            types: self.types,
+            comps: self.comps,
             archetypes: self.archetypes,
             idx: self.idx,
             len: mid,
         };
 
         let rhs = Self {
-            types: self.types,
+            comps: self.comps,
             archetypes: self.archetypes,
             idx: mid,
             len: self.len,
@@ -246,7 +246,7 @@ pub struct QueryParIterIntoIter<'q, S>
 where
     S: QuerySpec,
 {
-    types: &'q [(u16, <S::Fetch as Fetch<'q>>::Ty)],
+    comps: &'q [(u16, <S::Fetch as Fetch<'q>>::Ty)],
     archetypes: &'q [Archetype],
     idx: u32,
     len: u32,
@@ -269,9 +269,9 @@ where
                 self.idx += 1;
                 return Some(val);
             } else {
-                match self.types.split_first() {
+                match self.comps.split_first() {
                     Some(((idx, ty), rest)) => {
-                        self.types = rest;
+                        self.comps = rest;
 
                         let archetype = &self.archetypes[*idx as usize];
                         self.idx = 0;
@@ -309,9 +309,9 @@ where
                 self.len_back -= 1;
                 return Some(val);
             } else {
-                match self.types.split_last() {
+                match self.comps.split_last() {
                     Some(((idx, ty), rest)) => {
-                        self.types = rest;
+                        self.comps = rest;
 
                         let archetype = &self.archetypes[*idx as usize];
                         self.idx_back = 0;
@@ -339,7 +339,7 @@ where
 {
     fn len(&self) -> usize {
         let len = self
-            .types
+            .comps
             .iter()
             .map(|(idx, _)| self.archetypes[*idx as usize].len())
             .sum::<u32>()


### PR DESCRIPTION
This reduces the number of dynamic borrow checks to one per component instead of one per archetype, thereby avoiding dynamic allocations for the reference wrappers.

However, it also means that e.g. `World::get_mut` can now fail due overlapping borrows for entities in different archetypes which would have worked before.