### PR TITLE
Fix miscompilations due to noalias annotations on references.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-ecs"
 description = "reasonably simple entity component system"
-version = "0.6.8"
+version = "0.6.9"
 edition = "2018"
 rust-version = "1.51"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]


### PR DESCRIPTION
Also brings `Comp` and `CompMut` in line with how `FetchRead` and `FetchWrite` are implemented.