### PR TITLE
Consolidate World::get(_mut) into World::query_one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-ecs"
 description = "reasonably simple entity component system"
-version = "0.6.10"
+version = "0.7.0"
 edition = "2018"
 rust-version = "1.51"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -198,8 +198,8 @@ fn get_component(bencher: &mut Bencher, spawn: fn(&mut World)) {
 
         let ent = *entities.next().unwrap();
 
-        let _pos = world.get_mut::<Pos>(ent).unwrap();
-        let _vel = world.get::<Vel>(ent);
+        let mut comp = world.query_one::<(&mut Pos, Option<&Vel>)>(ent).unwrap();
+        let (_pos, _vel) = comp.get_mut();
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ mod world;
 pub use crate::{
     query::{Matches, Query, QueryIter, QueryMap, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
-    world::{Comp, CompMut, Entity, World},
+    world::{Entity, QueryOne, World},
 };
 
 #[cfg(feature = "rayon")]

--- a/src/query.rs
+++ b/src/query.rs
@@ -56,9 +56,9 @@ use crate::rayon::QueryParIter;
 ///     }
 /// }
 ///
-/// assert_eq!(*world.get::<i32>(entity1).unwrap(), 65);
-/// assert_eq!(*world.get::<f32>(entity1).unwrap(), 2.0);
-/// assert_eq!(*world.get::<i32>(entity2).unwrap(), -1);
+/// assert_eq!(*world.query_one::<&i32>(entity1).unwrap().get(), 65);
+/// assert_eq!(*world.query_one::<&f32>(entity1).unwrap().get(), 2.0);
+/// assert_eq!(*world.query_one::<&i32>(entity2).unwrap().get(), -1);
 /// ```
 ///
 /// Use of a prepared query that is stored and reused for optimization:
@@ -422,6 +422,8 @@ where
     S: QuerySpec,
 {
     /// Access the queried components of the given [Entity]
+    ///
+    /// Available only if the components do not include unique references.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Using a query specification is more flexible without implying additional costs.