### PR TITLE
Enabling cloning a world by manually collect clone and copy functions for the component types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rs-ecs"
 description = "reasonably simple entity component system"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2018"
 rust-version = "1.51"
 authors = ["Adam Reichold <adam.reichold@t-online.de>"]

--- a/src/borrow_flags.rs
+++ b/src/borrow_flags.rs
@@ -72,6 +72,17 @@ impl BorrowFlags {
     }
 }
 
+impl Clone for BorrowFlags {
+    fn clone(&self) -> Self {
+        Self(
+            self.0
+                .iter()
+                .map(|(id, _)| (*id, UnsafeCell::new(0)))
+                .collect(),
+        )
+    }
+}
+
 pub struct Ref<'a>(&'a UnsafeCell<isize>);
 
 impl<'a> Ref<'a> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod resources;
 mod world;
 
 pub use crate::{
+    archetype::Cloner,
     query::{Matches, Query, QueryIter, QueryMap, QueryRef, QuerySpec, With, Without},
     resources::{Res, ResMut, Resources},
     world::{Entity, QueryOne, World},

--- a/src/resources.rs
+++ b/src/resources.rs
@@ -137,10 +137,10 @@ impl<R> DerefMut for ResMut<'_, R> {
     }
 }
 
-type TypeIdMap<V> = HashMap<TypeId, V, BuildHasherDefault<TypeIdHasher>>;
+pub type TypeIdMap<V> = HashMap<TypeId, V, BuildHasherDefault<TypeIdHasher>>;
 
 #[derive(Default)]
-struct TypeIdHasher(u64);
+pub struct TypeIdHasher(u64);
 
 impl Hasher for TypeIdHasher {
     fn write_u64(&mut self, val: u64) {


### PR DESCRIPTION
This approach does not rely on specialization and is therefore compatible with stable Rust. When specialization is stabilized, the clone functions can become part of `TypeMetadata` and the `clone(&mut self, cloner: &Cloner) -> Self` methods can become proper implementations of `trait Clone`.

Closes #33 